### PR TITLE
refactor(user): refactor changing username, email, and password usecase

### DIFF
--- a/src/auth/application/auth.service.ts
+++ b/src/auth/application/auth.service.ts
@@ -35,7 +35,10 @@ export class AuthService implements IAuthService {
       const { password: hashedPassword, ...user } =
         await this.userService.getByUsername(username);
 
-      await new Bcrypt().compare(password, hashedPassword);
+      const isCorrect = await new Bcrypt().compare(password, hashedPassword);
+      if (!isCorrect) {
+        throw new UnauthorizedException('username or password incorrect');
+      }
 
       return user;
     } catch (e: unknown) {

--- a/src/auth/application/auth.service.ts
+++ b/src/auth/application/auth.service.ts
@@ -16,6 +16,7 @@ import { IAuthRepository } from '../domain/auth.repository.interface';
 import { PrismaService } from '../../common/prisma.service';
 import { convertMilisToDate } from '../../utils/date';
 import { AuthValidation } from './auth.validation';
+import { AuthEntity } from '../domain/auth.entity';
 
 @Injectable()
 export class AuthService implements IAuthService {
@@ -117,5 +118,9 @@ export class AuthService implements IAuthService {
     );
 
     await this.authRepository.revokeAllByUserId(userId);
+  }
+
+  async get(refreshToken: string): Promise<AuthEntity> {
+    return await this.authRepository.get(refreshToken);
   }
 }

--- a/src/auth/domain/auth.service.interface.ts
+++ b/src/auth/domain/auth.service.interface.ts
@@ -1,5 +1,6 @@
 import { RefreshReq, RegisterDto } from '../interface/http/auth.request';
 import { JWTSignPayload, TokenResponse } from '../interface/http/auth.response';
+import { AuthEntity } from './auth.entity';
 
 export interface IAuthService {
   register(req: RegisterDto): Promise<void>;
@@ -7,4 +8,5 @@ export interface IAuthService {
   logout(refreshToken: string): Promise<void>;
   refresh(req: RefreshReq): Promise<TokenResponse>;
   revokeAllByUserId(userId: string): Promise<void>;
+  get(refreshToken: string): Promise<AuthEntity>;
 }

--- a/src/user/application/user.service.ts
+++ b/src/user/application/user.service.ts
@@ -1,7 +1,13 @@
-import { forwardRef, Inject, Injectable } from '@nestjs/common';
+import {
+  BadRequestException,
+  forwardRef,
+  Inject,
+  Injectable,
+} from '@nestjs/common';
 import { IUserRepository } from '../domain/user.repository.interface';
 import {
   AddUserDto,
+  ChangeUserPasswordDto,
   EditUserProfileDto,
   mapAddUserDto,
 } from '../interface/http/user.request';
@@ -146,15 +152,45 @@ export class UserService implements IUserService {
     return data;
   }
 
-  async changePassword(id: string, password: string): Promise<void> {
+  async changePassword(id: string, req: ChangeUserPasswordDto): Promise<void> {
     this.validationService.validate(UserValidation.CHANGE_PASSWORD, {
       id,
-      password,
+      ...req,
     });
 
-    await this.userRepository.verify(id);
+    const bcrypt = new Bcrypt();
+    const { password: hashedPassword } = await this.userRepository.getById(id);
 
-    const hashedPassword = await new Bcrypt().hash(password);
-    await this.userRepository.changePassword(id, hashedPassword);
+    // check if the old password is correct
+    const isOldPasswordCorrect = await bcrypt.compare(
+      req.oldPassword,
+      hashedPassword,
+    );
+    if (!isOldPasswordCorrect) {
+      throw new BadRequestException('old password incorrect');
+    }
+
+    // prevent using the same password
+    const isSamePassword = await bcrypt.compare(
+      req.newPassword,
+      hashedPassword,
+    );
+    if (isSamePassword) {
+      throw new BadRequestException(
+        'new password cannot be the same as the old password',
+      );
+    }
+
+    const newHashedPassword = await bcrypt.hash(req.newPassword);
+
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    await this.prismaService.$transaction(async (tx) =>
+      Promise.all([
+        this.userRepository.changePassword(id, newHashedPassword),
+
+        // revoke all authentication tokens
+        this.authService.revokeAllByUserId(id),
+      ]),
+    );
   }
 }

--- a/src/user/application/user.service.ts
+++ b/src/user/application/user.service.ts
@@ -121,15 +121,16 @@ export class UserService implements IUserService {
 
     const user = await this.getById(id);
 
-    let data: TokenResponse;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    await this.prismaService.$transaction(async (tx) => {
-      await this.userRepository.changeEmail(id, email);
-      await this.authService.revokeAllByUserId(id);
-      data = await this.authService.login({ ...user, email });
-    });
+    return await this.prismaService.$transaction(async (tx) => {
+      Promise.all([
+        this.userRepository.changeEmail(id, email),
+        this.authService.revokeAllByUserId(id),
+      ]);
 
-    return data;
+      // return new access and refresh token
+      return await this.authService.login({ ...user, email });
+    });
   }
 
   async changeUsername(
@@ -147,15 +148,16 @@ export class UserService implements IUserService {
 
     const user = await this.getById(id);
 
-    let data: TokenResponse;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    await this.prismaService.$transaction(async (tx) => {
-      await this.userRepository.changeUsername(id, username);
-      await this.authService.revokeAllByUserId(id);
-      data = await this.authService.login({ ...user, username });
-    });
+    return await this.prismaService.$transaction(async (tx) => {
+      Promise.all([
+        this.userRepository.changeUsername(id, username),
+        this.authService.revokeAllByUserId(id),
+      ]);
 
-    return data;
+      // return new access and refresh token
+      return await this.authService.login({ ...user, username });
+    });
   }
 
   async changePassword(id: string, req: ChangeUserPasswordDto): Promise<void> {

--- a/src/user/application/user.service.ts
+++ b/src/user/application/user.service.ts
@@ -116,13 +116,16 @@ export class UserService implements IUserService {
   ): Promise<TokenResponse> {
     this.validationService.validate(UserValidation.CHANGE_EMAIL, { id, email });
 
+    // verify the refresh token
+    await this.authService.get(refreshToken);
+
     const user = await this.getById(id);
 
     let data: TokenResponse;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     await this.prismaService.$transaction(async (tx) => {
       await this.userRepository.changeEmail(id, email);
-      await this.authService.logout(refreshToken);
+      await this.authService.revokeAllByUserId(id);
       data = await this.authService.login({ ...user, email });
     });
 
@@ -139,13 +142,16 @@ export class UserService implements IUserService {
       username,
     });
 
+    // verify the refresh token
+    await this.authService.get(refreshToken);
+
     const user = await this.getById(id);
 
     let data: TokenResponse;
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     await this.prismaService.$transaction(async (tx) => {
       await this.userRepository.changeUsername(id, username);
-      await this.authService.logout(refreshToken);
+      await this.authService.revokeAllByUserId(id);
       data = await this.authService.login({ ...user, username });
     });
 

--- a/src/user/application/user.validation.ts
+++ b/src/user/application/user.validation.ts
@@ -43,6 +43,7 @@ export class UserValidation {
 
   static readonly CHANGE_PASSWORD: ZodType = z.object({
     id: z.string().uuid(),
-    password: z.string().min(8),
+    oldPassword: z.string().min(8),
+    newPassword: z.string().min(8),
   });
 }

--- a/src/user/domain/user.service.interface.ts
+++ b/src/user/domain/user.service.interface.ts
@@ -1,5 +1,9 @@
 import { Role } from '@prisma/client';
-import { AddUserDto, EditUserProfileDto } from '../interface/http/user.request';
+import {
+  AddUserDto,
+  ChangeUserPasswordDto,
+  EditUserProfileDto,
+} from '../interface/http/user.request';
 import {
   UserResponseDto,
   UserWithPasswordResponseDto,
@@ -23,5 +27,5 @@ export interface IUserService {
     refreshToken: string,
     username: string,
   ): Promise<TokenResponse>;
-  changePassword(id: string, password: string): Promise<void>;
+  changePassword(id: string, req: ChangeUserPasswordDto): Promise<void>;
 }

--- a/src/user/interface/http/user.controller.ts
+++ b/src/user/interface/http/user.controller.ts
@@ -1,4 +1,5 @@
 import {
+  Body,
   Controller,
   Delete,
   Get,
@@ -44,7 +45,8 @@ import {
   ApiUnauthorizedResponse,
   getSchemaPath,
 } from '@nestjs/swagger';
-import { EditUserProfileDto } from './user.request';
+import { ChangeUserPasswordDto, EditUserProfileDto } from './user.request';
+import { User } from 'src/common/decorator/user.decorator';
 
 @Controller('/api/v1/users')
 @ApiExtraModels(
@@ -327,17 +329,6 @@ export class UserController {
   @UseGuards(JwtGuard)
   @ApiOperation({ summary: 'change password' })
   @ApiBearerAuth('Authorization')
-  @ApiBody({
-    schema: {
-      type: 'object',
-      properties: {
-        password: {
-          type: 'string',
-          example: 'example',
-        },
-      },
-    },
-  })
   @ApiOkResponse({
     description: 'Successfully change password',
     type: StatusResponseDto,
@@ -354,12 +345,11 @@ export class UserController {
     description: 'Internal Server Error',
     type: InternalServerResponse,
   })
-  async changePassword(@Req() req: Request): Promise<StatusResponseDto> {
-    const user = req.user as JWTSignPayload;
-
-    const password = req.body.password;
-
-    await this.userService.changePassword(user.id, password);
+  async changePassword(
+    @User('id') id: string,
+    @Body() body: ChangeUserPasswordDto,
+  ): Promise<StatusResponseDto> {
+    await this.userService.changePassword(id, body);
 
     return new StatusResponseDto();
   }

--- a/src/user/interface/http/user.controller.ts
+++ b/src/user/interface/http/user.controller.ts
@@ -46,7 +46,7 @@ import {
   getSchemaPath,
 } from '@nestjs/swagger';
 import { ChangeUserPasswordDto, EditUserProfileDto } from './user.request';
-import { User } from 'src/common/decorator/user.decorator';
+import { User } from '../../../common/decorator/user.decorator';
 
 @Controller('/api/v1/users')
 @ApiExtraModels(

--- a/src/user/interface/http/user.request.ts
+++ b/src/user/interface/http/user.request.ts
@@ -29,3 +29,11 @@ export class EditUserProfileDto {
   @ApiProperty({ example: 'example' })
   name: string;
 }
+
+export class ChangeUserPasswordDto {
+  @ApiProperty({ example: 'verystrongpassword' })
+  oldPassword: string;
+
+  @ApiProperty({ example: 'newstrongpassword' })
+  newPassword: string;
+}

--- a/src/utils/Bcrypt.ts
+++ b/src/utils/Bcrypt.ts
@@ -1,4 +1,4 @@
-import { Injectable, UnauthorizedException } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
 import * as bcrypt from 'bcrypt';
 
 @Injectable()
@@ -9,10 +9,7 @@ export class Bcrypt {
     return await bcrypt.hash(password, this.saltRound);
   }
 
-  async compare(password: string, hashedPassword: string) {
-    const isCorrect = await bcrypt.compare(password, hashedPassword);
-    if (!isCorrect) {
-      throw new UnauthorizedException('username or password incorrect');
-    }
+  async compare(password: string, hashedPassword: string): Promise<boolean> {
+    return await bcrypt.compare(password, hashedPassword);
   }
 }

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -251,6 +251,8 @@ describe('UserController (e2e)', () => {
       expect(refreshCookie).toContain('SameSite=Strict');
       expect(body.status).toEqual('success');
       expect(body.data.access).toBeDefined();
+
+      adminRefresh = refreshCookie.split(';')[0].split('refresh=')[1];
     });
   });
 
@@ -289,6 +291,8 @@ describe('UserController (e2e)', () => {
       expect(refreshCookie).toContain('SameSite=Strict');
       expect(body.status).toEqual('success');
       expect(body.data.access).toBeDefined();
+
+      adminRefresh = refreshCookie.split(';')[0].split('refresh=')[1];
     });
   });
 

--- a/test/user.e2e-spec.ts
+++ b/test/user.e2e-spec.ts
@@ -293,6 +293,19 @@ describe('UserController (e2e)', () => {
   });
 
   describe('PATCH /api/v1/users/password', () => {
+    const invalidOldPasswordRequest = {
+      oldPassword: 'invalidpassword',
+      newPassword: admin.password,
+    };
+    const invalidNewPasswordRequest = {
+      oldPassword: admin.password,
+      newPassword: admin.password,
+    };
+    const validRequest = {
+      oldPassword: admin.password,
+      newPassword: 'newpassword',
+    };
+
     it('should return 401 when request credentials invalid', async () => {
       const response = await request(app.getHttpServer()).patch(
         '/api/v1/users/password',
@@ -308,14 +321,37 @@ describe('UserController (e2e)', () => {
 
       const errors = response.body.errors;
       expect(response.status).toEqual(400);
-      expect(errors[0].path).toEqual('password');
+      expect(errors[0].path).toEqual('oldPassword');
+      expect(errors[1].path).toEqual('newPassword');
+    });
+
+    it('should return 400 when old password request invalid', async () => {
+      const response = await request(app.getHttpServer())
+        .patch('/api/v1/users/password')
+        .set('Authorization', `Bearer ${adminAccess}`)
+        .send(invalidOldPasswordRequest);
+
+      expect(response.status).toEqual(400);
+      expect(response.body.message).toEqual('old password incorrect');
+    });
+
+    it('should return 400 when new password is the same as the old password request invalid', async () => {
+      const response = await request(app.getHttpServer())
+        .patch('/api/v1/users/password')
+        .set('Authorization', `Bearer ${adminAccess}`)
+        .send(invalidNewPasswordRequest);
+
+      expect(response.status).toEqual(400);
+      expect(response.body.message).toEqual(
+        'new password cannot be the same as the old password',
+      );
     });
 
     it('should change password successfully', async () => {
       const response = await request(app.getHttpServer())
         .patch('/api/v1/users/password')
         .set('Authorization', `Bearer ${adminAccess}`)
-        .send(admin);
+        .send(validRequest);
 
       expect(response.status).toEqual(200);
       expect(response.body.status).toEqual('success');


### PR DESCRIPTION
- verify and revoke all refresh tokens when changing email or username
- return a response directly from the transaction when changing email or username
- enhance the changePassword security
user must input the old password to change the password which will throw an error if incorrect. the new password cannot be the same as the old password. after success, it will change the password and revoke all authentication tokens to log out the user from every device