### PR TITLE
refactor(order): Add `isFinish` to OrderProgressResponseDto and update edit order progress request type

### DIFF
--- a/src/order/application/order.validation.ts
+++ b/src/order/application/order.validation.ts
@@ -103,6 +103,6 @@ export class OrderValidation {
   });
 
   static readonly EDIT_PROGRESS_BY_ID: ZodType = z.object({
-    isFinish: z.preprocess((v: string) => v === 'true', z.boolean()),
+    isFinish: z.boolean(),
   });
 }

--- a/src/order/interface/http/order.controller.ts
+++ b/src/order/interface/http/order.controller.ts
@@ -284,7 +284,6 @@ export class OrderController {
   @Put(':id/progresses/:progressId')
   @UseInterceptors(NoFilesInterceptor())
   @ApiOperation({ summary: 'edit order progress by id' })
-  @ApiConsumes('multipart/form-data')
   @ApiBearerAuth('Authorization')
   @ApiOkResponse({
     description: 'Successfully edit order progress by id',

--- a/src/order/interface/http/order.response.ts
+++ b/src/order/interface/http/order.response.ts
@@ -28,6 +28,9 @@ export class OrderProgressResponseDto {
 
   @ApiProperty({ example: 1 })
   step: number;
+
+  @ApiProperty({ example: true })
+  isFinish: boolean;
 }
 
 export class GetAllOrderResponseDto {

--- a/test/order.e2e-spec.ts
+++ b/test/order.e2e-spec.ts
@@ -302,7 +302,7 @@ describe('OrderController (e2e)', () => {
       const response = await request(app.getHttpServer())
         .put(`/api/v1/orders/${orderId}/progresses/${editProgressId}`)
         .set('Authorization', `Bearer ${accessToken}`)
-        .field({ isFinished: true });
+        .send({ isFinish: true });
 
       expect(response.status).toEqual(200);
       expect(response.body.status).toEqual('success');


### PR DESCRIPTION
- added `isFinish` property to `OrderProgressResponseDto` in `getOrderByIdResponse` because `isFinish` was needed to track progress status on the frontend
- to simplify data handling, we changed the request method type for editing order progress from `multipart/form-data` to `application/json`.