### PR TITLE
refactor(order): change add & edit order request data to JSON string format

### DIFF
--- a/src/order/application/order.service.ts
+++ b/src/order/application/order.service.ts
@@ -2,7 +2,9 @@ import { Inject, Injectable, NotFoundException } from '@nestjs/common';
 import { GdriveService } from '../../common/gdrive.service';
 import { IOrderService } from '../domain/order.service.interface';
 import {
+  AddOrderDataDto,
   AddOrderDto,
+  EditOrderDataDto,
   EditOrderDto,
   EditOrderProgressDto,
   GetAllOrderDto,
@@ -21,6 +23,7 @@ import { IOrderRepository } from '../domain/order.repository.interface';
 import { PrismaService } from '../../common/prisma.service';
 import * as fs from 'fs';
 import { OrderValidation } from './order.validation';
+import { JsonUtil } from 'src/utils/json.util';
 
 @Injectable()
 export class OrderService implements IOrderService {
@@ -34,42 +37,29 @@ export class OrderService implements IOrderService {
 
   async add(req: AddOrderDto, userId: string): Promise<AddOrderResponseDto> {
     const orderPictures: OrderPictureDto[] = [];
-    try {
-      req = this.validationService.validate(OrderValidation.ADD, req);
+    const data = JsonUtil.parse<AddOrderDataDto>(req.data);
 
-      // verify order progresses
-      await this.processService.verifyAll(req.progresses, userId);
-      // upload and mapping pictures
-      const folderId = process.env.GDRIVE_ORDER_FOLDER_ID;
-      const uploadTasks = req.pictures.map((picture) =>
-        this.gdriveService.upload(picture, folderId),
-      );
-      const uploadRes = await Promise.all(uploadTasks);
-      uploadRes.forEach((response) => {
-        orderPictures.push({
-          id: response.id,
-          url: `https://drive.google.com/uc?id=${response.id}`,
-        });
+    try {
+      this.validationService.validate(OrderValidation.ADD, {
+        pictures: req.pictures,
+        ...data,
       });
 
+      // verify order progresses
+      await this.processService.verifyAll(data.progresses, userId);
+
+      orderPictures.push(...(await this.uploadOrderPictures(req.pictures)));
+
       return await this.orderRepository.add(
-        mapAddOrderDto(userId, req),
+        mapAddOrderDto(userId, data),
         orderPictures,
-        req.progresses,
+        data.progresses,
       );
     } catch (e) {
-      await Promise.allSettled(
-        orderPictures.map((picture) => this.gdriveService.delete(picture.id)),
-      );
-
+      await this.rollbackUploadedPictures(orderPictures);
       throw e;
     } finally {
-      // remove the local file
-      if (Array.isArray(req.pictures)) {
-        await Promise.allSettled(
-          req.pictures.map((picture) => fs.promises.unlink(picture.path)),
-        );
-      }
+      await this.cleanupLocalFiles(req.pictures);
     }
   }
 
@@ -87,71 +77,42 @@ export class OrderService implements IOrderService {
 
   async editById(id: string, userId: string, req: EditOrderDto): Promise<void> {
     const newPictures: OrderPictureDto[] = [];
+    const data = JsonUtil.parse<EditOrderDataDto>(req.data);
+
     try {
-      req = this.validationService.validate(OrderValidation.EDIT_BY_ID, req);
+      this.validationService.validate(OrderValidation.EDIT_BY_ID, {
+        addedPictures: req.addedPictures,
+        ...data,
+      });
 
       // verify order and order progresses
       await this.orderRepository.verify(id, userId);
-      await this.processService.verifyAll(req.addedProgresses, userId);
+      await this.processService.verifyAll(data.addedProgresses, userId);
 
       // verify if processes already exist. if exist, remove from request
-      const progressVerifications = req.addedProgresses.map(
-        async (progressId, index) => {
-          try {
-            await this.orderRepository.verifyProgress(progressId, id);
-            req.addedProgresses.splice(index, 1);
-          } catch (e) {
-            if (!(e instanceof NotFoundException)) {
-              throw e;
-            }
-          }
-        },
+      data.addedProgresses = await this.filterExistingProgresses(
+        data.addedProgresses,
+        id,
       );
-      await Promise.all(progressVerifications);
 
-      // upload and mapping pictures
-      for (const picture of req.addedPictures) {
-        const response = await this.gdriveService.upload(
-          picture,
-          process.env.GDRIVE_ORDER_FOLDER_ID,
-        );
-
-        newPictures.push({
-          id: response.id,
-          url: `https://drive.google.com/uc?id=${response.id}`,
-        });
-      }
+      newPictures.push(...(await this.uploadOrderPictures(req.addedPictures)));
 
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       await this.prismaService.$transaction(async (tx) => {
-        await this.orderRepository.addProgresses(id, req.addedProgresses);
-        await this.orderRepository.deleteProgresses(id, req.deletedProgresses);
+        await this.orderRepository.addProgresses(id, data.addedProgresses);
+        await this.orderRepository.deleteProgresses(id, data.deletedProgresses);
         await this.orderRepository.editById(
           id,
-          mapEditOrderDto(req),
+          mapEditOrderDto(data),
           newPictures,
         );
-        for (const pictureId of req.deletedPictures) {
-          try {
-            await this.gdriveService.delete(pictureId);
-          } catch (e) {
-            if (!e.message.includes('File not found')) {
-              throw e;
-            }
-          }
-        }
+        await this.deleteRemovedPictures(data.deletedPictures);
       });
     } catch (e) {
-      await Promise.allSettled(
-        newPictures.map((picture) => this.gdriveService.delete(picture.id)),
-      );
-
+      await this.rollbackUploadedPictures(newPictures);
       throw e;
     } finally {
-      // remove the local file
-      await Promise.allSettled(
-        req.addedPictures.map((picture) => fs.promises.unlink(picture.path)),
-      );
+      await this.cleanupLocalFiles(req.addedPictures);
     }
   }
 
@@ -171,15 +132,80 @@ export class OrderService implements IOrderService {
     userId: string,
     req: EditOrderProgressDto,
   ): Promise<void> {
-    req = this.validationService.validate(
-      OrderValidation.EDIT_PROGRESS_BY_ID,
-      req,
-    );
+    this.validationService.validate(OrderValidation.EDIT_PROGRESS_BY_ID, req);
 
     // verify the order with userId
     await this.orderRepository.verify(orderId, userId);
     // verify if the order progress exist
     await this.orderRepository.verifyProgress(id, orderId);
     await this.orderRepository.editProgressById(id, orderId, req.isFinish);
+  }
+
+  private async uploadOrderPictures(
+    pictures: Express.Multer.File[],
+  ): Promise<OrderPictureDto[]> {
+    const folderId = process.env.GDRIVE_ORDER_FOLDER_ID;
+    const uploadTasks = pictures.map((picture) =>
+      this.gdriveService.upload(picture, folderId),
+    );
+
+    const uploadRes = await Promise.all(uploadTasks);
+    return uploadRes.map((response) => ({
+      id: response.id,
+      url: `https://drive.google.com/uc?id=${response.id}`,
+    }));
+  }
+
+  private async rollbackUploadedPictures(
+    pictures: OrderPictureDto[],
+  ): Promise<void> {
+    await Promise.allSettled(
+      pictures.map((picture) => this.gdriveService.delete(picture.id)),
+    );
+  }
+
+  private async cleanupLocalFiles(
+    pictures: Express.Multer.File[],
+  ): Promise<void> {
+    if (Array.isArray(pictures)) {
+      await Promise.allSettled(
+        pictures.map((picture) => fs.promises.unlink(picture.path)),
+      );
+    }
+  }
+
+  private async filterExistingProgresses(
+    progresses: string[],
+    orderId: string,
+  ): Promise<string[]> {
+    const validProgresses: string[] = [];
+
+    await Promise.all(
+      progresses.map(async (progressId) => {
+        try {
+          await this.orderRepository.verifyProgress(progressId, orderId);
+        } catch (e) {
+          if (e instanceof NotFoundException) {
+            validProgresses.push(progressId);
+          } else {
+            throw e;
+          }
+        }
+      }),
+    );
+
+    return validProgresses;
+  }
+
+  private async deleteRemovedPictures(pictureIds: string[]): Promise<void> {
+    for (const pictureId of pictureIds) {
+      try {
+        await this.gdriveService.delete(pictureId);
+      } catch (e) {
+        if (!e.message.includes('File not found')) {
+          throw e;
+        }
+      }
+    }
   }
 }

--- a/src/order/application/order.validation.ts
+++ b/src/order/application/order.validation.ts
@@ -4,35 +4,21 @@ import { z, ZodType } from 'zod';
 export class OrderValidation {
   static readonly ADD: ZodType = z
     .object({
-      pictures: z.array(z.any()).nonempty(),
-      size: z.preprocess((v: string) => parseInt(v), z.number().min(10)),
-      layer: z.preprocess(
-        (v: string) => parseInt(v) || null,
-        z.number().nullable(),
-      ),
-      isUseTopper: z.preprocess((v: string) => {
-        if (v === 'true') return true;
-        if (v === 'false') return false;
-        return v;
-      }, z.boolean()),
+      pictures: z.array(z.any()).max(3).nonempty(),
+      size: z.number().int().min(10),
+      layer: z.number().int().positive().optional().nullable(),
+      isUseTopper: z.boolean(),
       pickupTime: z.preprocess(
         (v: string) => (isNaN(parseInt(v)) ? v : BigInt(v)),
         z.bigint().positive(),
       ),
-      text: z.string(),
-      textColor: z.string(),
-      price: z.preprocess((v: string) => parseFloat(v), z.number().min(0)),
-      downPayment: z.preprocess(
-        (v: string) => parseFloat(v),
-        z.number().min(0),
-      ),
+      text: z.string().max(255),
+      textColor: z.string().max(120),
+      price: z.number().min(0),
+      downPayment: z.number().min(0),
       telp: z.string().regex(NUMBER_REGEX, 'should contains only number'),
-      notes: z.string().optional(),
-      progresses: z.preprocess((v) => {
-        if (Array.isArray(v)) return [...new Set(v)];
-        if (typeof v === 'string') return [v];
-        return v;
-      }, z.array(z.string().uuid()).nonempty()),
+      notes: z.string().optional().nullable(),
+      progresses: z.array(z.string().uuid()).nonempty(),
     })
     .refine((schema) => schema.downPayment <= schema.price, {
       path: ['downPayment'],
@@ -46,51 +32,23 @@ export class OrderValidation {
 
   static readonly EDIT_BY_ID: ZodType = z
     .object({
-      size: z.preprocess((v: string) => parseInt(v), z.number().min(10)),
-      layer: z.preprocess(
-        (v: string) => parseInt(v) || null,
-        z.number().nullable(),
-      ),
-      isUseTopper: z.preprocess((v: string) => {
-        if (v === 'true') return true;
-        if (v === 'false') return false;
-        return v;
-      }, z.boolean()),
+      size: z.number().int().min(10),
+      layer: z.number().int().positive().optional().nullable(),
+      isUseTopper: z.boolean(),
       pickupTime: z.preprocess(
         (v: string) => (isNaN(parseInt(v)) ? v : BigInt(v)),
         z.bigint().positive(),
       ),
-      text: z.string(),
-      textColor: z.string(),
-      price: z.preprocess((v: string) => parseFloat(v), z.number().min(0)),
-      downPayment: z.preprocess(
-        (v: string) => parseFloat(v),
-        z.number().min(0),
-      ),
+      text: z.string().max(255),
+      textColor: z.string().max(120),
+      price: z.number().min(0),
+      downPayment: z.number().min(0),
       telp: z.string().regex(NUMBER_REGEX, 'should contains only number'),
-      notes: z.string().optional(),
-      deletedPictures: z.preprocess(
-        (v) => {
-          if (v === undefined) return [];
-          if (Array.isArray(v)) return [...new Set(v)];
-          if (typeof v === 'string') return [v];
-          return v;
-        },
-        z.array(z.string().min(5)),
-      ),
-      addedProgresses: z.preprocess((v) => {
-        if (v === undefined) return [];
-        if (Array.isArray(v)) return [...new Set(v)];
-        if (typeof v === 'string') return [v];
-        return v;
-      }, z.array(z.string().uuid())),
-      deletedProgresses: z.preprocess((v) => {
-        if (v === undefined) return [];
-        if (Array.isArray(v)) return [...new Set(v)];
-        if (typeof v === 'string') return [v];
-        return v;
-      }, z.array(z.string().uuid())),
-      addedPictures: z.array(z.any()).optional(),
+      notes: z.string().optional().nullable(),
+      deletedPictures: z.array(z.string().min(5)),
+      addedProgresses: z.array(z.string().uuid()),
+      deletedProgresses: z.array(z.string().uuid()),
+      addedPictures: z.array(z.any()).max(3),
     })
     .refine((schema) => schema.downPayment <= schema.price, {
       path: ['downPayment'],

--- a/src/order/interface/http/order.controller.ts
+++ b/src/order/interface/http/order.controller.ts
@@ -247,7 +247,6 @@ export class OrderController {
     @Body() body: EditOrderDto,
   ): Promise<StatusResponseDto> {
     body.addedPictures = files?.addedPictures ?? [];
-
     const data = await this.orderService.editById(id, userId, body);
 
     return new ApiResponseDto(data);

--- a/src/order/interface/http/order.request.ts
+++ b/src/order/interface/http/order.request.ts
@@ -6,32 +6,23 @@ import {
 import { v4 as uuid } from 'uuid';
 import { OrderStatus } from './order.response';
 
-export class AddOrderDto {
-  @ApiProperty({
-    type: 'array',
-    items: {
-      type: 'string',
-      format: 'binary',
-    },
-  })
-  pictures: Express.Multer.File[];
-
-  @ApiProperty({ example: 16 })
+export class AddOrderDataDto {
+  @ApiProperty({ minimum: 10, description: 'must be at least 10', example: 16 })
   size: number;
 
-  @ApiProperty({ required: false, example: 2 })
+  @ApiProperty({ required: false, example: 2, nullable: true })
   layer?: number;
 
   @ApiProperty({ example: true })
   isUseTopper: boolean;
 
-  @ApiProperty({ example: 1730952000000 })
-  pickupTime: bigint;
+  @ApiProperty({ example: '1730952000000' })
+  pickupTime: string;
 
-  @ApiProperty({ example: 'Happy Birthday' })
+  @ApiProperty({ maxLength: 255, example: 'Happy Birthday' })
   text: string;
 
-  @ApiProperty({ example: 'Red' })
+  @ApiProperty({ maxLength: 120, example: 'Red' })
   textColor: string;
 
   @ApiProperty({ format: 'double', example: 20000 })
@@ -43,23 +34,42 @@ export class AddOrderDto {
   @ApiProperty({ example: '6289898888' })
   telp: string;
 
-  @ApiProperty({ required: false, example: 'call me' })
+  @ApiProperty({ required: false, example: 'call me', nullable: true })
   notes?: string;
 
-  @ApiProperty({ type: 'array', items: { type: 'string' } })
+  @ApiProperty({
+    type: [String],
+    description: 'Array of process IDs (UUIDs)',
+    example: [],
+  })
   progresses: string[];
+}
+
+export class AddOrderDto {
+  @ApiProperty({
+    type: 'array',
+    items: {
+      type: 'string',
+      format: 'binary',
+    },
+    maxItems: 3,
+  })
+  pictures: Express.Multer.File[];
+
+  @ApiProperty({ type: AddOrderDataDto })
+  data: string;
 }
 
 export const mapAddOrderDto = (
   userId: string,
-  req: AddOrderDto,
+  req: AddOrderDataDto,
 ): OrderEntity => ({
   id: uuid(),
   userId,
   size: req.size,
   layer: req.layer,
   isUseTopper: req.isUseTopper,
-  pickupTime: req.pickupTime,
+  pickupTime: BigInt(req.pickupTime),
   text: req.text,
   textColor: req.textColor,
   price: req.price,
@@ -81,23 +91,23 @@ export class GetAllOrderDto {
   status: OrderStatus;
 }
 
-export class EditOrderDto {
-  @ApiProperty({ example: 16 })
+export class EditOrderDataDto {
+  @ApiProperty({ minimum: 10, description: 'must be at least 10', example: 16 })
   size: number;
 
-  @ApiProperty({ required: false, example: 2 })
+  @ApiProperty({ required: false, example: 2, nullable: true })
   layer?: number;
 
   @ApiProperty({ example: false })
   isUseTopper: boolean;
 
-  @ApiProperty({ example: 1730952000000 })
-  pickupTime: bigint;
+  @ApiProperty({ example: '1730952000000' })
+  pickupTime: string;
 
-  @ApiProperty({ example: 'Pyy Birthday' })
+  @ApiProperty({ maxLength: 255, example: 'Pyy Birthday' })
   text: string;
 
-  @ApiProperty({ example: 'Blue' })
+  @ApiProperty({ maxLength: 120, example: 'Blue' })
   textColor: string;
 
   @ApiProperty({ format: 'double', example: 20000 })
@@ -109,9 +119,32 @@ export class EditOrderDto {
   @ApiProperty({ example: '6289898888' })
   telp: string;
 
-  @ApiProperty({ required: false, example: 'call me' })
+  @ApiProperty({ required: false, example: 'call me', nullable: true })
   notes?: string;
 
+  @ApiProperty({
+    type: [String],
+    description: 'Array of picture IDs. Can be empty.',
+    example: [],
+  })
+  deletedPictures: string[];
+
+  @ApiProperty({
+    type: [String],
+    description: 'Array of process IDs (UUIDs). Can be empty.',
+    example: [],
+  })
+  addedProgresses: string[];
+
+  @ApiProperty({
+    type: [String],
+    description: 'Array of process IDs (UUIDs). Can be empty.',
+    example: [],
+  })
+  deletedProgresses: string[];
+}
+
+export class EditOrderDto {
   @ApiProperty({
     type: 'array',
     items: {
@@ -119,24 +152,19 @@ export class EditOrderDto {
       format: 'binary',
     },
     required: false,
+    maxItems: 3,
   })
   addedPictures: Express.Multer.File[];
 
-  @ApiProperty({ type: 'array', items: { type: 'string' }, required: false })
-  deletedPictures: string[];
-
-  @ApiProperty({ type: 'array', items: { type: 'string' }, required: false })
-  addedProgresses: string[];
-
-  @ApiProperty({ type: 'array', items: { type: 'string' }, required: false })
-  deletedProgresses: string[];
+  @ApiProperty({ type: EditOrderDataDto })
+  data: string;
 }
 
-export const mapEditOrderDto = (req: EditOrderDto): EditOrderEntity => ({
+export const mapEditOrderDto = (req: EditOrderDataDto): EditOrderEntity => ({
   size: req.size,
   layer: req.layer,
   isUseTopper: req.isUseTopper,
-  pickupTime: req.pickupTime,
+  pickupTime: BigInt(req.pickupTime),
   text: req.text,
   textColor: req.textColor,
   price: req.price,

--- a/src/utils/json.util.ts
+++ b/src/utils/json.util.ts
@@ -1,0 +1,11 @@
+import { BadRequestException } from '@nestjs/common';
+
+export class JsonUtil {
+  static parse<T>(data: string, errorMessage = 'Invalid JSON format'): T {
+    try {
+      return JSON.parse(data) as T;
+    } catch {
+      throw new BadRequestException(errorMessage);
+    }
+  }
+}

--- a/test/order.e2e-spec.ts
+++ b/test/order.e2e-spec.ts
@@ -138,7 +138,7 @@ describe('OrderController (e2e)', () => {
       const response = await request(app.getHttpServer())
         .post('/api/v1/orders')
         .set('Authorization', `Bearer ${accessToken}`)
-        .field({ notes: addReq.notes });
+        .field({ data: JSON.stringify({ notes: addReq.notes }) });
 
       const errors = response.body.errors;
       expect(response.status).toEqual(400);
@@ -158,7 +158,7 @@ describe('OrderController (e2e)', () => {
       const response = await request(app.getHttpServer())
         .post('/api/v1/orders')
         .set('Authorization', `Bearer ${accessToken}`)
-        .field(addReq)
+        .field({ data: JSON.stringify(addReq) })
         .attach('pictures', filePath);
 
       const body = response.body;
@@ -263,7 +263,7 @@ describe('OrderController (e2e)', () => {
       const response = await request(app.getHttpServer())
         .put(`/api/v1/orders/${orderId}`)
         .set('Authorization', `Bearer ${accessToken}`)
-        .field({ notes: addReq.notes });
+        .field({ data: JSON.stringify({ notes: addReq.notes }) });
 
       const errors = response.body.errors;
       expect(response.status).toEqual(400);
@@ -281,7 +281,7 @@ describe('OrderController (e2e)', () => {
       const response = await request(app.getHttpServer())
         .put(`/api/v1/orders/${orderId}`)
         .set('Authorization', `Bearer ${accessToken}`)
-        .field(editReq);
+        .field({ data: JSON.stringify(editReq) });
 
       expect(response.status).toEqual(200);
       expect(response.body.status).toEqual('success');


### PR DESCRIPTION
- change add & edit order request payload to use a JSON string for structured data to improve data handling
- kept file upload unchanged
- handle JSON parsing in service for add & edit
- update validation to parse JSON correctly
- fix addedProgresses, deletedProgresses, and addedPictures validation payload of edit order process that shouldn't be undefined
- limit uploaded pictures in validation to maximum of 3 files
- make AddOrderDto & EditOrderDto data property to string and move the previous properties into separate dto to be used in JSON parsing
- refactor add & edit order service by separate process into a private function for better readability, better error handling, and maintainability
- update e2e testing by parsing add & edit order input to JSON string